### PR TITLE
initial user_profile api

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 Auth server for SAGE to let users authenticate using their institutional identity provider and create tokens for access to other SAGE resources.
 
 
-# Test environments 
+# Test environments
 
 
 Both test environments described below are not to be used in production, they are only for development/testing purposes!
 
-In production the default login is authentication delegated to Globus Auth, the login will not work in a local deployment without SSL certificate and client registration with the Globus OAuth server. Instead, the test deployments via the docker-compose create a native Django test user (see [testing-entrypoint.sh](testing-entrypoint.sh)) and the developer can login via [http://localhost:8000/login](http://localhost:8000/login) as `test` with password `test`.  
+In production the default login is authentication delegated to Globus Auth, the login will not work in a local deployment without SSL certificate and client registration with the Globus OAuth server. Instead, the test deployments via the docker-compose create a native Django test user (see [testing-entrypoint.sh](testing-entrypoint.sh)) and the developer can login via [http://localhost:8000/login](http://localhost:8000/login) as `test` with password `test`.
 
 
 
@@ -54,8 +54,8 @@ curl -X POST -H 'Accept: application/json; indent=4' -H 'Content-Type: applicati
 ```
 The basicAuth used here is the base64 encoding of `sage-api-server:test`, example:
 
-```console
-echo -n 'sage-api-server:test' | base64 
+```bash
+echo -n 'sage-api-server:test' | base64
 ```
 
 Example response:
@@ -65,17 +65,24 @@ Example response:
     "scope": "default",    # A JSON string containing a space-separated list of scopes associated with this token.
     "client_id": "<user>",
     "username": "<user>",
-    "exp": 1591632949      # The unix timestamp (integer timestamp, number of seconds since January 1, 1970 UTC) indicating when this token will expire. 
+    "exp": 1591632949      # The unix timestamp (integer timestamp, number of seconds since January 1, 1970 UTC) indicating when this token will expire.
 }
 ```
 
 # Dev
 
 
-```console
+```bash
 
 docker exec -ti sage-auth_db_1 mysql -u root -p -D SAGEDB
 
 pasword: testtest
 
+```
+
+
+# Tests
+
+```bash
+docker exec -it sage-auth-sage-auth-1 sh -c 'USE_SQLITE3=1 python manage.py test'
 ```

--- a/app/webapp/webapp/models.py
+++ b/app/webapp/webapp/models.py
@@ -17,6 +17,9 @@ class Profile(models.Model):
     organization = models.CharField(max_length=30, blank=True)
     department = models.CharField(max_length=30, blank=True)
 
+    def __str__(self):
+        return '{}; {}'.format(self.user, self.sage_username)
+
 
 
 @receiver(post_save, sender=User)

--- a/app/webapp/webapp/settings.py
+++ b/app/webapp/webapp/settings.py
@@ -43,19 +43,26 @@ INSTALLED_APPS = [
     'social_django',
     'webapp',
     'rest_framework',
-    'django_prometheus'
+    'django_prometheus',
+    'corsheaders'
 ]
 
 MIDDLEWARE = [
     'django_prometheus.middleware.PrometheusBeforeMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django_prometheus.middleware.PrometheusAfterMiddleware',
+]
+
+
+CORS_ALLOWED_ORIGIN_REGEXES = [
+    r"^https://\w+\.sagecontinuum\.org$",
 ]
 
 ROOT_URLCONF = 'webapp.urls'

--- a/app/webapp/webapp/test_user_api.py
+++ b/app/webapp/webapp/test_user_api.py
@@ -1,0 +1,76 @@
+from django.test import TestCase
+from django.contrib.auth.models import User
+from .views import util_create_sage_token
+import json
+
+
+
+class UserProfileTests(TestCase):
+
+    def testUserProfileNoAuth(self):
+        r = self.client.get('/user_profile/test')
+        self.assertEqual(r.status_code, 403)
+
+    def testUserProfileBadAuth(self):
+        r = self.client.get('/user_profile/test')
+        self.assertEqual(r.status_code, 403)
+
+        r = self.client.get('/user_profile/test', HTTP_AUTHORIZATION='Notvalid')
+        self.assertEqual(r.status_code, 403)
+
+        r = self.client.get('/user_profile/test', HTTP_AUTHORIZATION='Sage some_foo')
+        self.assertEqual(r.status_code, 403)
+
+        data = {'bio': 'a new bio'}
+        r = self.client.put('/user_profile/test', data, HTTP_AUTHORIZATION='Sage some_foo', content_type='application/json')
+        self.assertEqual(r.status_code, 403)
+
+    def testUserProfileBadBearer(self):
+        r = self.client.get('/user_profile/test', HTTP_AUTHORIZATION='Foo some_foo')
+        self.assertEqual(r.status_code, 403)
+
+    def testUserProfileView(self):
+        token = self.setUpUserAndToken('test')
+        authorization = f'Sage {token}'
+
+        r = self.client.get('/user_profile/test', HTTP_AUTHORIZATION=authorization)
+        self.assertEqual(r.status_code, 200)
+
+        u = json.loads(r.content)
+        self.assertEqual(u['bio'], 'a bio')
+        self.assertEqual(u['department'], 'a department')
+        self.assertEqual(u['organization'], 'an org')
+
+    def testUserProfileUpdate(self):
+        token = self.setUpUserAndToken('test')
+        authorization = f'Sage {token}'
+
+        # do an update
+        data = {'bio': 'a new bio', 'department': 'new department'}
+        r = self.client.put('/user_profile/test', data, HTTP_AUTHORIZATION=authorization, content_type='application/json')
+        self.assertEqual(r.status_code, 200)
+
+        u = json.loads(r.content)
+        self.assertEqual(u['bio'], 'a new bio')
+        self.assertEqual(u['department'], 'new department')
+        self.assertEqual(u['organization'], 'an org')
+
+        # check db
+        r = self.client.get('/user_profile/test', HTTP_AUTHORIZATION=authorization)
+        self.assertEqual(r.status_code, 200)
+
+        u = json.loads(r.content)
+        self.assertEqual(u['bio'], 'a new bio')
+        self.assertEqual(u['department'], 'new department')
+        self.assertEqual(u['organization'], 'an org')
+
+    def setUpUserAndToken(self, username):
+        '''create a user with an empty profile and random token'''
+        user = User.objects.create_user(username, '', 'test')
+        user.profile.sage_username = username
+        user.profile.bio = 'a bio'
+        user.profile.department = 'a department'
+        user.profile.organization = 'an org'
+        user.save()
+        token = util_create_sage_token(username)
+        return token.tokenValue

--- a/app/webapp/webapp/urls.py
+++ b/app/webapp/webapp/urls.py
@@ -27,7 +27,6 @@ from django.conf.urls.static import static
 
 urlpatterns = [
     path('user_profile/<str:sage_username>', user_api.UserProfile.as_view()),
-    path('user_profile/', user_api.UserProfile.as_view()),
     path('token_info/', views.TokenInfo.as_view()),
     path('admin/', admin.site.urls),
     path('', views.home, name='home'),

--- a/app/webapp/webapp/urls.py
+++ b/app/webapp/webapp/urls.py
@@ -26,7 +26,7 @@ from django.conf.urls.static import static
 
 
 urlpatterns = [
-    path('user_profile/<str:username>', user_api.UserProfile.as_view()),
+    path('user_profile/<str:sage_username>', user_api.UserProfile.as_view()),
     path('user_profile/', user_api.UserProfile.as_view()),
     path('token_info/', views.TokenInfo.as_view()),
     path('admin/', admin.site.urls),

--- a/app/webapp/webapp/urls.py
+++ b/app/webapp/webapp/urls.py
@@ -16,6 +16,7 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import include, path
 from . import views
+from . import user_api
 
 from django.conf.urls import url # for native login
 from django.contrib.auth import views as auth_views # for native login
@@ -25,6 +26,8 @@ from django.conf.urls.static import static
 
 
 urlpatterns = [
+    path('user_profile/<str:username>', user_api.UserProfile.as_view()),
+    path('user_profile/', user_api.UserProfile.as_view()),
     path('token_info/', views.TokenInfo.as_view()),
     path('admin/', admin.site.urls),
     path('', views.home, name='home'),

--- a/app/webapp/webapp/user_api.py
+++ b/app/webapp/webapp/user_api.py
@@ -1,0 +1,103 @@
+from webapp.models import Token, Profile
+
+from django.utils import timezone
+from django.contrib.auth.models import User
+
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import exceptions
+from rest_framework import authentication
+
+
+
+def get_token_user(token):
+    try:
+        t_object = Token.objects.get(tokenValue=token)
+    except Token.DoesNotExist:
+        return None
+
+    if t_object == None:
+        return None
+
+    expires = t_object.expires
+
+    if expires == None or timezone.now() > expires:
+        return None
+
+    return t_object.user
+
+
+
+class Authentication(authentication.BaseAuthentication):
+    def authenticate(self, request):
+        token = request.headers.get('Authorization')
+
+        sage_username = get_token_user(token.split(' ')[1])
+
+        if not sage_username:
+            raise exceptions.AuthenticationFailed
+
+        try:
+            user_profile = Profile.objects.get(sage_username=sage_username)
+        except User.DoesNotExist:
+            raise exceptions.AuthenticationFailed('No such user profile')
+
+        # use sage user_profile instead of django auth User
+        request.sage_username = user_profile.sage_username
+
+        return (user_profile, None)
+
+
+
+immutable_fields = ['id', 'user_id', 'sage_username']
+
+class UserProfile(APIView):
+    authentication_classes = [Authentication]
+
+    def get(self, request, **kwargs):
+        '''
+        Example request:
+            curl -H 'Authorization: Sage <token>' localhost:8000/user_profile/<username>
+        '''
+
+        user_param = kwargs.get('username')
+        username = request.sage_username
+
+        if user_param != username:
+            raise exceptions.AuthenticationFailed
+
+
+        if username:
+            data = Profile.objects.filter(sage_username=username).values()
+        else:
+            data = Profile.objects.all().values() # todo(nc): remove full listing, and allow limited queries
+
+        return Response({'data': data})
+
+
+    def post(self, request, **kwargs):
+        '''
+        Example request:
+            curl -X POST -H "Content-Type: application/json" -H 'Authorization: Sage <token>'
+            localhost:8000/user_profile/<username> -d '{"bio": "some bio"}'
+        '''
+        user_param = kwargs.get('username')
+        username = request.sage_username
+
+        if user_param != username:
+            raise exceptions.AuthenticationFailed
+
+
+        record = Profile.objects.filter(sage_username=username)
+
+        for field in request.data.keys():
+            if field in immutable_fields:
+                continue
+
+            record.update(**{field: request.data[field]})
+
+        return Response(
+            Profile.objects.filter(sage_username=username).values()
+        )
+
+

--- a/app/webapp/webapp/user_api.py
+++ b/app/webapp/webapp/user_api.py
@@ -38,13 +38,13 @@ class Authentication(BaseAuthentication):
         try:
             [bearer, token] = auth.split(' ')
         except:
-           raise exceptions.AuthenticationFailed('Invalid format')
-
-        if not token:
-            raise exceptions.AuthenticationFailed('No token provided')
+            raise exceptions.AuthenticationFailed('Invalid Authorization header format')
 
         if bearer.lower() != 'sage':
             raise exceptions.AuthenticationFailed(f'Invalid bearer: {bearer}')
+
+        if not token:
+            raise exceptions.AuthenticationFailed('No token provided')
 
         sage_username = get_token_user(token)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ djangorestframework==3.12.4
 prometheus-client==0.10.1
 django-prometheus==2.1.0
 gunicorn==20.1.0
+django-cors-headers==3.13.0


### PR DESCRIPTION
* This is kind of a POC on using the custom authentication middleware to update user_profile data.
* All auth-related http request errors are `401` (`exceptions.AuthenticationFailed`)

Todo:
* update default branch to main
* add some tests
* ~~add first/last names~~ this is actually part of auth_user
* don't require trailing slashes in API paths